### PR TITLE
fix: wal.Entry moves cursor

### DIFF
--- a/src/wal/widgets/entry.py
+++ b/src/wal/widgets/entry.py
@@ -78,7 +78,9 @@ class Entry(wx.TextCtrl, mixins.DataWidgetMixin):
     def set_value(self, val):
         self.my_changes = True
         self.value = utils.tr(val)
+        cursor_pos = self.get_cursor_pos()
         self.SetValue(self.value)
+        self.set_cursor_pos(cursor_pos)
 
     def set_editable(self, val):
         self.SetEditable(val)


### PR DESCRIPTION
When you edit a spot color name, backspace moves the cursor to home

Closes #322